### PR TITLE
Enhance/fuku global arguments

### DIFF
--- a/fuku/app.py
+++ b/fuku/app.py
@@ -155,6 +155,9 @@ class App(Module):
         ]))
 
     def get_my_context(self):
+        if self.client.args.app:
+            return {'app': self.client.args.app}
+
         sel = self.store_get('selected')
         if not sel:
             self.error('no app currently selected')

--- a/fuku/app.py
+++ b/fuku/app.py
@@ -1,7 +1,3 @@
-import os
-import stat
-
-from .db import get_rc_path
 from .module import Module
 from .utils import entity_already_exists
 
@@ -39,7 +35,6 @@ class App(Module):
         p.add_argument('domain', metavar='DOMAIN', help='domain name')
         p.add_argument('load_balancer_index', metavar='LOAD_BALANCER_INDEX', help='load balancer index')
         p.set_defaults(app_handler=self.handle_expose)
-
 
     def handle_list(self, args):
         self.list()
@@ -177,7 +172,7 @@ class EcsApp(App):
         ctx = self.get_context()
         vpc_id = self.get_module('cluster').get_vpc(ctx['cluster']).id
         alb_cli = self.get_boto_client('elbv2')
-        tg_arn = alb_cli.create_target_group(
+        alb_cli.create_target_group(
             Name=f'fuku-{ctx["cluster"]}-{name}',
             Protocol='HTTP',
             Port=80,

--- a/fuku/client.py
+++ b/fuku/client.py
@@ -4,9 +4,19 @@ from .db import get_default_db, save_db
 
 
 class Client(object):
+    global_arguments = {('app', 'application'), ('pg', 'DB instance')}
+
     def __init__(self):
         self.modules = []
         self.parser = argparse.ArgumentParser()
+
+        # global arguments
+        for arg, verbose_name in self.global_arguments:
+            self.parser.add_argument(
+                f'--{arg}', metavar=arg.upper(),
+                help=f'Global {verbose_name} argument overwriting context'
+            )
+
         self.db = get_default_db()
 
     def add_module(self, module):
@@ -22,6 +32,7 @@ class Client(object):
 
     def add_arguments(self):
         subp = self.parser.add_subparsers()
+
         for mod in self.modules:
             modp = subp.add_parser(mod.name)
             mod.add_arguments(modp)

--- a/fuku/db.py
+++ b/fuku/db.py
@@ -1,6 +1,5 @@
-import os
 import json
-# from tinydb import TinyDB
+import os
 
 
 def get_rc_path():

--- a/fuku/module.py
+++ b/fuku/module.py
@@ -1,15 +1,15 @@
-import os
-import sys
 import json
+import os
 import stat
+import sys
 import tempfile
 from contextlib import contextmanager
 from string import Template
 
 import boto3
 
-from .runner import run
 from .db import get_rc_path
+from .runner import run
 
 
 class Module(object):

--- a/fuku/pg.py
+++ b/fuku/pg.py
@@ -1,11 +1,11 @@
-import uuid
-import os
 import json
+import os
+import uuid
 from datetime import datetime, timedelta
 
-from .module import Module
 from .db import get_rc_path
-from .utils import gen_secret, gen_name
+from .module import Module
+from .utils import gen_name, gen_secret
 
 
 class Pg(Module):
@@ -222,7 +222,7 @@ class Pg(Module):
     #     self.cache(args.name, args.password)
 
     def cache(self, inst_name, db_name, password):
-        ctx = self.get_context() 
+        ctx = self.get_context()
         data = self.get_endpoint(inst_name)
         path = os.path.join(self.get_rc_path(), f'{inst_name}.pgpass')
         try:

--- a/fuku/pg.py
+++ b/fuku/pg.py
@@ -512,6 +512,9 @@ class Pg(Module):
         return sel
 
     def get_my_context(self):
+        if self.client.args.pg:
+            return {'dbinstance': self.client.args.pg}
+
         sel = self.store_get('selected')
         if not sel:
             self.error('no DB currently selected')

--- a/fuku/scripts/fuku
+++ b/fuku/scripts/fuku
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3.6
+# flake8:noqa
+# isort:skip_file
 
 import sys
+
 if sys.version_info < (3,6):
     sys.exit('Sorry, Python < 3.6 is not supported')
 

--- a/fuku/task.py
+++ b/fuku/task.py
@@ -99,7 +99,6 @@ class Task(Module):
         p.set_defaults(task_handler=self.handle_prune)
 
     def handle_list(self, args):
-        print(args)
         self.list(args.name)
 
     def list(self, name):

--- a/fuku/task.py
+++ b/fuku/task.py
@@ -2,12 +2,16 @@ import json
 
 from .module import Module
 from .utils import (
-    StoreKeyValuePair, StorePortPair,
-    env_to_dict, dict_to_env,
-    ports_to_dict, dict_to_ports,
-    volumes_to_dict, dict_to_volumes,
-    mounts_to_dict, dict_to_mounts,
-    entity_already_exists
+    StoreKeyValuePair,
+    StorePortPair,
+    dict_to_env,
+    dict_to_mounts,
+    dict_to_ports,
+    dict_to_volumes,
+    env_to_dict,
+    mounts_to_dict,
+    ports_to_dict,
+    volumes_to_dict,
 )
 
 
@@ -95,6 +99,7 @@ class Task(Module):
         p.set_defaults(task_handler=self.handle_prune)
 
     def handle_list(self, args):
+        print(args)
         self.list(args.name)
 
     def list(self, name):
@@ -260,7 +265,7 @@ class Task(Module):
 
     def ports_unset(self, name, values):
         app_task = self.get_app_task()
-        ctr_def = self.get_container_definition(task, name)
+        ctr_def = self.get_container_definition(app_task, name)
         ports = ports_to_dict(ctr_def['portMappings'])
         for p in values:
             try:
@@ -355,7 +360,6 @@ class Task(Module):
             except KeyError:
                 pass
         self.register_task(task)
-            
 
     def handle_prune(self, args):
         self.prune()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[flake8]
+ignore = E501
+max-line-length = 100
+
+[isort]
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_first_party = fuku
+multi_line_output = 3
+line_length = 100
+indent = 4
+include_trailing_comma = True
+not_skip = __init__.py


### PR DESCRIPTION
- Added `setup.cfg` to bring some consistency with isort and flake8
- flake8 and isort-ed some files
- Added global arguments for `app` and `pg` which overwrite the session context (or is used if no arg in the context)
This allows us to run commands like `fuku --app=XXX service redeploy fg` **without** having to `fuku app sl XXX`