### PR TITLE
Enhancements

### DIFF
--- a/fuku/module.py
+++ b/fuku/module.py
@@ -205,6 +205,10 @@ class Module(object):
         self.setup_boto_session(ctx)
         return boto3.client(resource)
 
+    def get_boto_paginator(self, client, resource, ctx={}):
+        self.setup_boto_session(ctx)
+        return boto3.client(client).get_paginator(resource)
+
     def puts3(self, key, value):
         ctx = self.get_context()
         s3 = self.get_boto_client('s3')

--- a/fuku/redis.py
+++ b/fuku/redis.py
@@ -51,6 +51,11 @@ class EcsRedis(Redis):
         p.add_argument('--group', metavar='GROUP', help='subnet group name')
         p.set_defaults(redis_handler=self.handle_make)
 
+        p = subp.add_parser('rm', help='remove a redis instance')
+        p.add_argument('name', metavar='NAME', help='instance name')
+        p.add_argument('--group', metavar='GROUP', help='subnet group name')
+        p.set_defaults(redis_handler=self.handle_remove)
+
         p = subp.add_parser('connect')
         p.add_argument('name', metavar='NAME', help='instance name')
         p.add_argument('target', metavar='TARGET', nargs='?', help='target task name')
@@ -130,3 +135,15 @@ class EcsRedis(Redis):
         for cache in data['CacheClusters']:
             name = cache['CacheClusterId']
             print(name)
+
+    def handle_remove(self, args):
+        self.remove(args.name, args.group)
+
+    def remove(self, name, group):
+        ec_cli = self.get_boto_client('elasticache')
+        subnet_group = self.get_id(name, group)
+
+        ec_cli.delete_cache_cluster(CacheClusterId=name)
+
+        if group:
+            ec_cli.delete_cache_subnet_group(CacheSubnetGroupName=subnet_group)

--- a/fuku/service.py
+++ b/fuku/service.py
@@ -4,10 +4,14 @@ from .module import Module
 from .runner import CommandError
 from .task import IGNORED_TASK_KWARGS
 from .utils import (
-    json_serial,
     StoreKeyValuePair,
-    env_to_string, ports_to_string, env_to_dict, dict_to_env,
-    mounts_to_string, volumes_to_dict
+    dict_to_env,
+    env_to_dict,
+    env_to_string,
+    json_serial,
+    mounts_to_string,
+    ports_to_string,
+    volumes_to_dict,
 )
 
 
@@ -460,7 +464,7 @@ class EcsService(Service):
         if expose:
             kwargs['loadBalancers'] = [
                 {
-                    'targetGroupArn': self.get_module('app').get_target_group_arn(),
+                    'targetGroupArn': self.get_module('app').get_target_group()['TargetGroupArn'],
                     'containerName': task_name,
                     'containerPort': 80
                 }

--- a/fuku/service.py
+++ b/fuku/service.py
@@ -340,6 +340,7 @@ class EcsService(Service):
 
         p = subp.add_parser('ls', help='list services')
         p.add_argument('task', metavar='TASK', nargs='?', help='task name')
+        p.add_argument('--long', '-l',  action='store_true', help='list long format')
         p.set_defaults(service_handler=self.handle_list)
 
         p = subp.add_parser('mk', help='make a service')
@@ -383,23 +384,18 @@ class EcsService(Service):
         p.add_argument('command', metavar='COMMAND', nargs='+', help='command to run')
         p.set_defaults(service_handler=self.handle_run)
 
-    def list(self, task_name):
+    def handle_list(self, args):
+        self.list(args.task, args.long)
+
+    def list(self, task_name, long=False):
         if task_name:
-            data = self.describe_service(task_name)
-            # ecs = self.get_boto_client('ecs')
-            # ctx = self.get_context()
-            # data = ecs.describe_services(
-            #     cluster=f'fuku-{ctx["cluster"]}',
-            #     services=[
-            #         f'fuku-{ctx["app"]}-{task_name}'
-            #     ]
-            # )['services'][0]
+            data = self.describe_service(task_name, long=long)
             print(json.dumps(data, default=json_serial, indent=2))
         else:
             for svc in self.iter_services(task_name):
                 print(svc)
 
-    def describe_service(self,task_name,  app_name=None):
+    def describe_service(self, task_name,  app_name=None, long=False):
         ecs = self.get_boto_client('ecs')
         ctx = self.get_context()
         app_name = ctx.get('app', app_name)
@@ -409,6 +405,17 @@ class EcsService(Service):
                 f'fuku-{app_name}-{task_name}'
             ]
         )['services'][0]
+
+        if not long:
+            # simple list shows summarised version of describe_services
+            data = {
+                key: val[:3] if key == 'events' else val
+                for key, val in data.items()
+                if key in {
+                    'serviceName', 'status', 'desiredCount', 'runningCount',
+                    'pendingCount', 'taskDefinition', 'events', 'deployments',
+                }
+            }
         return data
 
     def handle_make(self, args):


### PR DESCRIPTION
Added:
- `fuku app rm <app>`
- `fuku app hide <app>`
- `fuku pg db rm <app>`
- `fuku redis rm <app> --group <group>`
- `fuku task rm <task>`

Changed:
- `fuku app expose <domain> <load_balancer_index>` -> `fuku app expose <app> <domain>`
    It will now automatically discover which ELB has enough space for rules.
- We do not need create IAM groups to define an app anymore, target groups are enough to define an app.
- Made use of boto3 paginator objects to sort and filter AWS directly in the api.